### PR TITLE
avoid root "/" matches every passed in path on checking partialMatch

### DIFF
--- a/dist/amd/path-parser.js
+++ b/dist/amd/path-parser.js
@@ -1,7 +1,5 @@
 define('Path', function () { 'use strict';
 
-    var babelHelpers = {};
-
     function babelHelpers_classCallCheck (instance, Constructor) {
       if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -285,7 +283,13 @@ define('Path', function () { 'use strict';
                 // Check if partial match (start of given path matches regex)
                 // trailingSlash: falsy => non optional, truthy => optional
                 var source = optTrailingSlash(this.source, trailingSlash);
-                var match = this._urlMatch(path, new RegExp('^' + source));
+
+                var match = undefined;
+                if (source === '\\/') {
+                    if (path === '/' || path.indexOf('/?') === 0) match = {};
+                } else {
+                    match = this._urlMatch(path, new RegExp('^' + source));
+                }
 
                 if (!match) return match;
 

--- a/dist/commonjs/path-parser.js
+++ b/dist/commonjs/path-parser.js
@@ -267,7 +267,13 @@ var Path = (function () {
             // Check if partial match (start of given path matches regex)
             // trailingSlash: falsy => non optional, truthy => optional
             var source = optTrailingSlash(this.source, trailingSlash);
-            var match = this._urlMatch(path, new RegExp('^' + source));
+
+            var match = undefined;
+            if (source === '\\/') {
+                if (path === '/' || path.indexOf('/?') === 0) match = {};
+            } else {
+                match = this._urlMatch(path, new RegExp('^' + source));
+            }
 
             if (!match) return match;
 

--- a/dist/umd/path-parser.js
+++ b/dist/umd/path-parser.js
@@ -4,8 +4,6 @@
     (global.Path = factory());
 }(this, function () { 'use strict';
 
-    var babelHelpers = {};
-
     function babelHelpers_classCallCheck (instance, Constructor) {
       if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -289,7 +287,13 @@
                 // Check if partial match (start of given path matches regex)
                 // trailingSlash: falsy => non optional, truthy => optional
                 var source = optTrailingSlash(this.source, trailingSlash);
-                var match = this._urlMatch(path, new RegExp('^' + source));
+
+                var match = undefined;
+                if (source === '\\/') {
+                    if (path === '/' || path.indexOf('/?') === 0) match = {};
+                } else {
+                    match = this._urlMatch(path, new RegExp('^' + source));
+                }
 
                 if (!match) return match;
 

--- a/modules/Path.js
+++ b/modules/Path.js
@@ -199,7 +199,13 @@ export default class Path {
         // Check if partial match (start of given path matches regex)
         // trailingSlash: falsy => non optional, truthy => optional
         let source = optTrailingSlash(this.source, trailingSlash);
-        let match = this._urlMatch(path, new RegExp('^' + source));
+
+        let match;
+        if (source === '\\/') {
+          if (path === '/' || path.indexOf('/?') === 0) match = {};
+        } else {
+          match = this._urlMatch(path, new RegExp('^' + source));
+        }
 
         if (!match) return match;
 

--- a/test/main.js
+++ b/test/main.js
@@ -71,6 +71,16 @@ describe('Path', function () {
         path.build({ offset: 31, limit: 15 }, {ignoreSearch: true}).should.equal('/users');
     });
 
+    it('should correctly partialMatch "/"', function () {
+        var path = new Path('/');
+        // Successful match & partial match
+        path.partialMatch('/').should.eql({});
+
+        // Unsuccessful match
+        should.not.exist(path.match('/users?offset=31&order=asc'));
+        should.not.exist(path.partialMatch('/users?offset=31&order=asc'));
+    });
+
     it('should match and build paths of query parameters with square brackets', function () {
         var path = new Path('/users?offset&limit[]');
         path.build({ offset: 31, limit: ['15'] }).should.equal('/users?offset=31&limit[]=15');


### PR DESCRIPTION
using router5 having routes setup like:

```
router
  .addNode('home', '/?:lng')
  .addNode('page1', '/page1?:lng');
```

the home route will always match in RouteNode: https://github.com/troch/route-node/blob/master/modules/RouteNode.js#L147

as any url will match `^\/`
