### PR TITLE
fix: add possibility to use ' and : characters in path.

### DIFF
--- a/modules/Path.js
+++ b/modules/Path.js
@@ -1,7 +1,7 @@
 import { getSearch, withoutBrackets, parse, toObject } from 'search-params';
 
 const defaultOrConstrained = (match) =>
-    '(' + (match ? match.replace(/(^<|>$)/g, '') : '[a-zA-Z0-9-_.~%]+') + ')';
+    '(' + (match ? match.replace(/(^<|>$)/g, '') : '[a-zA-Z0-9-_.~%\':]+') + ')';
 
 const rules = [
     {

--- a/test/main.js
+++ b/test/main.js
@@ -190,4 +190,11 @@ describe('Path', function () {
         path.partialTest('/university', { delimited: false }).should.eql({});
         path.partialTest('/univers/hello').should.eql({});
     });
+
+    it('should match with special characters in path', function () {
+        var path = new Path('/test/:name/test2');
+
+        path.partialTest('/test/he:re/test2').should.eql({ name: 'he:re' });
+        path.partialTest('/test/he\'re/test2').should.eql({ name: 'he\'re' });
+    });
 });


### PR DESCRIPTION
Currently : and ' characters are not matched in parameters. Those should be valid characters in URLs?
