### PR TITLE
Upgrade rollup and its config

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "mkdirp": "~0.5.1",
     "mocha": "~4.0.1",
     "rimraf": "~2.6.2",
-    "rollup": "~0.51.5",
-    "rollup-plugin-babel": "~3.0.2",
+    "rollup": "~0.53.3",
+    "rollup-plugin-babel": "~3.0.3",
     "should": "~13.1.3"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,10 +11,12 @@ const babelOptions = {
 };
 
 export default ['es', 'cjs'].map(format => ({
-    entry: 'modules/Path.js',
-    format,
+    input: 'modules/Path.js',
     plugins: [ babel(babelOptions) ],
-    moduleName: 'Path',
-    moduleId: 'Path',
-    dest: `dist/${format}/path-parser.js`
+    output: {
+        name: 'Path',
+        format,
+        file:`dist/${format}/path-parser.js`
+    },
+    moduleId: 'Path'
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,9 +2204,9 @@ rimraf@^2.2.8, rimraf@~2.6.2:
   dependencies:
     glob "^7.0.5"
 
-rollup-plugin-babel@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz#a2765dea0eaa8aece351c983573300d17497495b"
+rollup-plugin-babel@~3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz#63adedc863130327512a4a9006efc2241c5b7c15"
   dependencies:
     rollup-pluginutils "^1.5.0"
 
@@ -2217,9 +2217,9 @@ rollup-pluginutils@^1.5.0:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup@~0.51.5:
-  version "0.51.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.51.5.tgz#5caf9101fcaefe344065701ece7de697631a8035"
+rollup@~0.53.3:
+  version "0.53.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.3.tgz#e7b6777623df912bd0ca30dc24be791d6ebc8e5a"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Updated rollup.
Rollup renamed a bunch of keys, now we did too.
Updated rollup seems to break without the updated config. See [build 13](https://travis-ci.org/troch/path-parser/builds/326881614).
  