### PR TITLE
test for function with `typeof` not `instanceof`

### DIFF
--- a/src/Path.ts
+++ b/src/Path.ts
@@ -329,7 +329,7 @@ export class Path<T extends Record<string, any> = Record<string, any>> {
 
   private getParams(type: string | RegExp): string[] {
     const predicate =
-      type instanceof RegExp
+      type.constructor.name === 'RegExp'
         ? (t: Token) => type.test(t.type)
         : (t: Token) => t.type === type
 

--- a/src/Path.ts
+++ b/src/Path.ts
@@ -329,7 +329,7 @@ export class Path<T extends Record<string, any> = Record<string, any>> {
 
   private getParams(type: string | RegExp): string[] {
     const predicate =
-      type.constructor.name === 'RegExp'
+      typeof type !== 'string'
         ? (t: Token) => type.test(t.type)
         : (t: Token) => t.type === type
 

--- a/src/tokeniser.ts
+++ b/src/tokeniser.ts
@@ -21,7 +21,7 @@ const tokenise = (str: string, tokens: Token[] = []): Token[] => {
       match: match[0],
       val: match.slice(1, 2),
       otherVal: match.slice(2),
-      regex: rule.regex instanceof Function ? rule.regex(match) : rule.regex
+      regex: typeof rule.regex === 'function' ? rule.regex(match) : rule.regex
     })
 
     if (match[0].length < str.length) {


### PR DESCRIPTION
Allows environments (e.g. jest) to override the global `Function` constructor

Checking via `instanceof` resolved to false, which caused the Path#source property to be set incorrectly where `partialTest` would return `{}` rather than `null` when it wasn't meant to match

EDIT: actually, not sure if it is `jest` which is wrapping `Function` or the environment I am running my code in (Cloudflare Workers) which doesn't allow `eval`/`new Function`