### PR TITLE
support strict query params

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -34,7 +34,7 @@ const rules: IRule[] = [
   },
   {
     name: 'query-parameter',
-    pattern: /^(?:\?|&)(?::)?([a-zA-Z0-9-_]*[a-zA-Z0-9]{1})/
+    pattern: /^(?:\?|&)(?::)?([a-zA-Z0-9-_]*[a-zA-Z0-9]{1})(?:=([a-zA-Z0-9-_]+))?/
   },
   {
     name: 'delimiter',

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -126,6 +126,25 @@ describe('Path', () => {
     })
   })
 
+  it('should match and build paths of query parameters with strict value', () => {
+    const path = new Path('/pages?id&page=test&search')
+
+    expect(path.build()).toBe('/pages?page=test')
+    expect(path.build({ page: 'foo' })).toBe('/pages?page=foo')
+
+    const otherTestParams = {
+      id: 'test',
+      search: 'query'
+    }
+
+    expect(path.test('/pages?id=test&page=test&search=query')).toEqual({
+      ...otherTestParams,
+      page: 'test'
+    })
+
+    expect(path.test('/pages?id=test&page=foo&search=query')).toBeNull()
+  })
+
   it('should match and build paths with url and query parameters', () => {
     const path = new Path('/users/profile/:id-:id2?:id3')
     expect(path.hasQueryParams).toBe(true)


### PR DESCRIPTION
Hi. I appreciate you for this library!

I has query based routing in my project and that means it's required to match URLs with strictly matched params. This PR brings support for this feature.