### PR TITLE
use unicode-resilient approach to exclude sub delimiters

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -13,8 +13,6 @@
               / "*" / "+" / "," / ";" / "="
  */
 
-const excludeSubDelimiters = /[^!$'()*+,;|:]/g
-
 export type URLParamsEncodingType =
   | 'default'
   | 'uri'
@@ -22,8 +20,24 @@ export type URLParamsEncodingType =
   | 'none'
   | 'legacy'
 
-export const encodeURIComponentExcludingSubDelims = (segment: string): string =>
-  segment.replace(excludeSubDelimiters, match => encodeURIComponent(match))
+export const encodeURIComponentExcludingSubDelims = (
+  segment: string
+): string => {
+  // Define sub-delimiters to exclude from encoding
+  const subDelimiters = /[!$'()*+,;|:]/g
+
+  // Use Array.from to correctly handle characters represented by surrogate pairs
+  return Array.from(segment)
+    .map(char => {
+      // Check if the character is a sub-delimiter
+      if (subDelimiters.test(char)) {
+        return char // Return the character as is if it's a sub-delimiter
+      } else {
+        return encodeURIComponent(char) // Otherwise, encode it
+      }
+    })
+    .join('') // Join the array back into a string
+}
 
 const encodingMethods: Record<
   URLParamsEncodingType,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -50,6 +50,17 @@ describe('Path', () => {
     )
   })
 
+  it('should match and build paths with emojis in query parameters', () => {
+    const pathA = new Path('/home?emoji')
+
+    expect(pathA.build({ emoji: '🤗' })).toEqual('/home?emoji=%F0%9F%A4%97')
+
+    const path = new Path('/home?emoji')
+    expect(path.test('/home?emoji=%F0%9F%99%8C')).toEqual({
+      emoji: '🙌'
+    })
+  })
+
   it('should match and build paths with query parameters', () => {
     const path = new Path('/users?offset&limit', {
       queryParams: { booleanFormat: 'string' }


### PR DESCRIPTION
Fixes https://github.com/troch/route-node/issues/39
Fixes https://github.com/router5/router5/issues/499

Hello!

I know this library is probably in kind of a "done" state but I noticed some issues with emojis in query params and decided to investigate. In the end it turned out the `.replace` method breaks apart unicode characters in a way that will later trip up `encodeURIComponent`. 

Iterating over characters as done in this PR ensures that surrogate pairs are kept as-is and thus path building works as expected even when emojis are provided as part of path parameters. 

![Screenshot 2024-03-13 at 22 39 52](https://github.com/troch/path-parser/assets/97496/d3fc48a9-e814-4224-9b51-ec44e9073a1d)
([source](https://dmitripavlutin.com/what-every-javascript-developer-should-know-about-unicode/))

I also added some tests to demonstrate that this is working as intended.

Cheers